### PR TITLE
chore(dependabot): align config with reference repos (auto-merge + tiered cooldown)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,9 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      actions-minor-patch:
-        patterns:
-          - '*'
+      actions-all:
         update-types:
+          - major
           - minor
           - patch
 
@@ -23,10 +22,14 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 3
     groups:
       npm-development:
         dependency-type: development
         update-types:
+          - major
           - minor
           - patch
       npm-production:


### PR DESCRIPTION
Brings the dependabot configuration in line with chrisreddington/validate-dependabot and chrisreddington/validate-file-exists.

## Auto-merge

Already in place via `.github/workflows/dependabot-automerge.yml` (auto-approves and enables auto-merge for semver patch/minor updates from dependabot[bot]). No changes needed there — it was updated to fetch-metadata v3.1.0 in #163.

## Cooldown — finer-grained for npm

| ecosystem | old | new |
| --- | --- | --- |
| github-actions | default 7d | default 7d |
| npm | default 7d | default 7d, major 14d, minor 3d, patch 3d |
| devcontainers | default 7d | default 7d |

## Group changes

- **github-actions**: `actions-minor-patch` → `actions-all`, now includes major (auto-merge workflow still filters to minor/patch only, so majors will open PRs for manual review)
- **npm-development**: includes major (same rationale — dev deps get bundled, but only minor/patch auto-merges)
- **npm-production**: unchanged (majors stay out of the group, so production majors get their own PR for review)

## Behaviour summary

- Dependabot waits 3-14d before opening PRs (longer for majors)
- Patch/minor PRs auto-merge after approval + CI
- Major PRs require manual review
- All updates are grouped per ecosystem to reduce PR noise